### PR TITLE
Recover native checkbox functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ I decided to apply the rules to the edges as though there were permanatly dead c
 
 ### Flashing colours
 
-Having each cell light up in a different colour is an essential part of my implementation because that's what makes the grid look like a dancefloor!
+Having each cell light up in a different colour is an essential part of my implementation because that's what makes the grid look like a dancefloor! I initially approached this by having the JS reassign the `style.background` of each cell directly, but this stopped the native checkbox behaviour from working normally because the JS styles were overriding the `:checked` CSS psudoproperty.
+
+I did toy with re-writing the click to turn on/off functionality of the checkboxes using JS, but in the end found a more elegant solution: each cell colour is defined as a its own CSS class, which can then be re-assigned easily using JS. The moral of the story? Native JS/CSS expect you to keep all of the design in your CSS - and it's much easier if you go along with that in the first place!
 
 ### User input
 

--- a/main.css
+++ b/main.css
@@ -155,6 +155,34 @@ input[type="checkbox"] {
   transition: ease-in-out .5s;
 }
 
-input[type="checkbox"]:checked {
+/* input[type="checkbox"]:checked {
+  background: var(--highlight);
+} */
+
+.magenta:checked {
+  background: var(--magenta);
+}
+
+.green:checked {
+  background: var(--green);
+}
+
+.purple:checked {
+  background: var(--purple);
+}
+
+.darkblue:checked {
+  background: var(--darkblue);
+}
+
+.violet:checked {
+  background: var(--violet);
+}
+
+.cyan:checked {
+  background: var(--cyan);
+}
+
+.yellow:checked {
   background: var(--yellow);
 }

--- a/main.js
+++ b/main.js
@@ -9,8 +9,6 @@ const domWidthField = document.getElementById('width');
 const domHeightField = document.getElementById('height');
 const domPercentageField = document.getElementById('percentage');
 
-const colors = ['magenta', 'green', 'purple', 'darkblue', 'violet', 'cyan', 'yellow'];
-
 class conwayGrid {
   constructor(gridWidth, gridHeight, startTruePercent) {
     this.gridWidth = gridWidth;
@@ -75,7 +73,7 @@ class conwayGrid {
     const currentCell = this.currentValues[y][x];
     let neighbourCellsCount = 0;
     const neighbourCells = [
-      this.lookupCell(y-1, x-1),
+      this.lookupCell(y-1, x-1), // TODO: Swap X and Y for this whole array!
       this.lookupCell(y, x-1),
       this.lookupCell(y+1, x-1),
       this.lookupCell(y-1, x),
@@ -111,16 +109,22 @@ class conwayGrid {
     for (let y = 0; y < this.gridHeight; y++) {
       for (let x = 0; x < this.gridWidth; x++) {
         const cell = document.getElementById(`cb_${cellCount}`);
+        this.changeCellColor(cell);
         if (gridArray[y][x] === true) {
           cell.checked = true;
-          const color = colors[Math.floor(Math.random() * colors.length)];
-          cell.style.background = 'var(--' + color + ')';
         } else {
           cell.checked = false;
-          cell.style.background = 'var(--white)';
-        } // TODO: Stop this overriding the native CSS :selected state...
+        }
         cellCount++;
       }
+    }
+  }
+
+  changeCellColor(cell) {
+    const colors = ['magenta', 'green', 'purple', 'darkblue', 'violet', 'cyan', 'yellow'];
+    const newColor = colors[Math.floor(Math.random() * colors.length)];
+    for (let i = 0; i < colors.length; i++) {
+      cell.className = newColor;
     }
   }
 


### PR DESCRIPTION
- Define CSS classes for each colour
- Change JS to swap classes rather than assigning background colours directly
- Update README with explanation